### PR TITLE
SteamPump: change getCapability null side behaviour

### DIFF
--- a/src/main/java/gregblockutils/Machines/SteamPump.java
+++ b/src/main/java/gregblockutils/Machines/SteamPump.java
@@ -140,7 +140,7 @@ public class SteamPump extends MetaTileEntity {
 
     @Override
     public <T> T getCapability(Capability<T> capability, EnumFacing side) {
-        return (side == null || side.getAxis() == EnumFacing.Axis.Y) ? null : super.getCapability(capability, side);
+        return (side != null && side.getAxis() == EnumFacing.Axis.Y) ? null : super.getCapability(capability, side);
     }
 
     @Override


### PR DESCRIPTION
Previously if `SteamPump::getCapability` was called with a `null` `side`
then it would invariably return `null`, in conflict with the
`SteamPump::hasCapability` behaviour which defers to the `super`.

This commit brings the two behaviours in sync.

Fixes https://github.com/EmosewaPixel/GregBlock/issues/79.

As a side effect, TOP now shows tank levels for the `SteamPump`. I'm fairly
sure it didn't before.